### PR TITLE
[Partial] ✨Display and sort drivers by seniority

### DIFF
--- a/office/office.test.js
+++ b/office/office.test.js
@@ -1,0 +1,37 @@
+const formatOffice = require('./office').formatOffice;
+
+describe('office', function () {
+
+    describe('formatOffice', function () {
+        it('should format office for display', function () {
+            const OFFICE = {
+                id: 1423,
+                name: "Bordeaux",
+                address: {
+                    street: "39 Rue du Château d'Eau",
+                    city: "Bordeaux", country: "France", zip: "33000",
+                },
+                drivers: [{
+                    id: 3, vehicle: 'renault',
+                    first: 'Daniel', last: 'RICCARDO',
+                    seniority: 5, age: 30,
+                }, {
+                    id: 33, vehicle: 'Honda',
+                    first: 'Max', last: 'VERSTAPPEN',
+                    seniority: 3, age: 22,
+                }, {
+                    id: 14, vehicle: 'mercedes',
+                    first: 'Lewis', last: 'HAMILTON',
+                    seniority: 12, age: 34,
+                },
+                ]
+            };
+            const EXPECTED = {
+                name: "Bordeaux",
+                address: "39 Rue du Château d'Eau, Bordeaux, France 33000",
+                drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
+            };
+            expect(formatOffice(OFFICE)).toEqual(EXPECTED);
+        });
+    });
+});


### PR DESCRIPTION
## What does it do:

Change the way drivers are displayed for offices.

Mods to `formatOffice()` to:
- Display driver seniority in parens after each driver name
- Sort by driver seniority (descending)

**Before:**
```
   drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
```

**After:**
```
   drivers: "Lewis HAMILTON (12), Daniel RICCARDO (5), Max VERSTAPPEN (3)"
```

## Context:
This was requested by our PM based on feedback from Executive team. ([JIRA-1234](http://yahoo.com))

## To Reproduce:
See Unit Tests