### PR TITLE
[Rebase] - ✨Display and sort drivers by seniority

### DIFF
--- a/office/README.md
+++ b/office/README.md
@@ -45,4 +45,5 @@ const officeDisplay = formatOffice(officeJson);
 
 Notes:
 - The `address` object is de-structured into a single string.
-- The `drivers` array is mapped into a single, comma-delimited string.
+- The `drivers` array is sorted by seniority and then mapped into a single,
+  comma-delimited string.

--- a/office/office.js
+++ b/office/office.js
@@ -1,11 +1,17 @@
 // Format driver for display
 function formatDriver(driver) {
-    return `${driver.first} ${driver.last}`;
+    return `${driver.first} ${driver.last} (${driver.seniority})`;
+}
+
+// I love you javascript
+function sortDriver(d1, d2) {
+    return d2.seniority - d1.seniority;
 }
 
 // Format drivers for display
 function formatDrivers(drivers) {
     return drivers
+        .sort(sortDriver)
         .map(formatDriver)
         .join(', ');
 }

--- a/office/office.js
+++ b/office/office.js
@@ -17,7 +17,7 @@ function formatOffice(office) {
     // Display name is just office name.
     displayOffice.name = office.name;
 
-    // Simple address foomat
+    // Simple address format
     const address = office.address;
     const street = address.street;
     const city = address.city;

--- a/office/office.js
+++ b/office/office.js
@@ -1,3 +1,15 @@
+// Format driver for display
+function formatDriver(driver) {
+    return `${driver.first} ${driver.last}`;
+}
+
+// Format drivers for display
+function formatDrivers(drivers) {
+    return drivers
+        .map(formatDriver)
+        .join(', ');
+}
+
 // Format an office object for easy display
 function formatOffice(office) {
     const displayOffice = {};
@@ -13,10 +25,8 @@ function formatOffice(office) {
     const zip = address.zip;
     displayOffice.address = `${street}, ${city}, ${country} ${zip}`;
 
-    displayOffice.drivers =
-        office.drivers
-            .map(driver => `${driver.first} ${driver.last}`)
-            .join(', ');
+    // Simple drivers format
+    displayOffice.drivers = formatDrivers(office.drivers);
 
     return displayOffice;
 };

--- a/office/office.test.js
+++ b/office/office.test.js
@@ -1,0 +1,37 @@
+const formatOffice = require('./office').formatOffice;
+
+describe('office', function () {
+
+    describe('formatOffice', function () {
+        it('should format office for display', function () {
+            const OFFICE = {
+                id: 1423,
+                name: "Bordeaux",
+                address: {
+                    street: "39 Rue du Château d'Eau",
+                    city: "Bordeaux", country: "France", zip: "33000",
+                },
+                drivers: [{
+                    id: 3, vehicle: 'renault',
+                    first: 'Daniel', last: 'RICCARDO',
+                    seniority: 5, age: 30,
+                }, {
+                    id: 33, vehicle: 'Honda',
+                    first: 'Max', last: 'VERSTAPPEN',
+                    seniority: 3, age: 22,
+                }, {
+                    id: 14, vehicle: 'mercedes',
+                    first: 'Lewis', last: 'HAMILTON',
+                    seniority: 12, age: 34,
+                },
+                ]
+            };
+            const EXPECTED = {
+                name: "Bordeaux",
+                address: "39 Rue du Château d'Eau, Bordeaux, France 33000",
+                drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
+            };
+            expect(formatOffice(OFFICE)).toEqual(EXPECTED);
+        });
+    });
+});

--- a/office/office.test.js
+++ b/office/office.test.js
@@ -29,7 +29,7 @@ describe('office', function () {
             const EXPECTED = {
                 name: "Bordeaux",
                 address: "39 Rue du Château d'Eau, Bordeaux, France 33000",
-                drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
+                drivers: "Lewis HAMILTON (12), Daniel RICCARDO (5), Max VERSTAPPEN (3)"
             };
             expect(formatOffice(OFFICE)).toEqual(EXPECTED);
         });


### PR DESCRIPTION
## What does it do:

Change the way drivers are displayed for offices.

Mods to `formatOffice()` to:
- Display driver seniority in parens after each driver name
- Sort by driver seniority (descending)

**Before:**
```
   drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
```

**After:**
```
   drivers: "Lewis HAMILTON (12), Daniel RICCARDO (5), Max VERSTAPPEN (3)"
```

## Context:
This was requested by our PM based on feedback from Executive team. ([JIRA-1234](http://yahoo.com))

## To Reproduce:
See Unit Tests