### PR TITLE
✨ [Office] Show seniority and sort drivers

### DIFF
--- a/office/README.md
+++ b/office/README.md
@@ -45,4 +45,4 @@ const officeDisplay = formatOffice(officeJson);
 
 Notes:
 - The `address` object is de-structured into a single string.
-- The `drivers` array is mapped into a single, comma-delimited string.
+- The `drivers` array is mapped into a single, comma-delimited string, sorted by seniority.

--- a/office/office.js
+++ b/office/office.js
@@ -1,6 +1,6 @@
 // Format driver for easy display
 function formatDriver(driver) {
-    return `${driver.first} ${driver.last}`;
+    return `${driver.first} ${driver.last} (${driver.seniority})`;
 }
 
 // Format drivers for easy display

--- a/office/office.js
+++ b/office/office.js
@@ -17,7 +17,7 @@ function formatOffice(officeJson) {
     // Display name is just office name.
     displayOffice.name = officeJson.name;
 
-    // Simple address foormat
+    // Simple address format
     const address = officeJson.address;
     const street = address.street;
     const city = address.city;

--- a/office/office.js
+++ b/office/office.js
@@ -1,3 +1,15 @@
+// Format driver for easy display
+function formatDriver(driver) {
+    return `${driver.first} ${driver.last}`;
+}
+
+// Format drivers for easy display
+function formatDrivers(drivers) {
+    return drivers
+        .map(formatDriver)
+        .join(', ');
+}
+
 // Format an office object for easy display
 function formatOffice(officeJson) {
     const displayOffice = {};
@@ -13,10 +25,8 @@ function formatOffice(officeJson) {
     const zip = address.zip;
     displayOffice.address = `${street}, ${city}, ${country} ${zip}`;
 
-    displayOffice.drivers =
-        officeJson.drivers
-            .map(driver => `${driver.first} ${driver.last}`)
-            .join(', ');
+    // Display drivers in a list
+    displayOffice.drivers = formatDrivers(officeJson.drivers);
 
     return displayOffice;
 };

--- a/office/office.js
+++ b/office/office.js
@@ -6,8 +6,13 @@ function formatDriver(driver) {
 // Format drivers for easy display
 function formatDrivers(drivers) {
     return drivers
+        .sort(sortDriver)
         .map(formatDriver)
         .join(', ');
+}
+
+function sortDriver(d1, d2) {
+    return d2.seniority - d1.seniority;
 }
 
 // Format an office object for easy display

--- a/office/office.test.js
+++ b/office/office.test.js
@@ -1,0 +1,37 @@
+const formatOffice = require('./office').formatOffice;
+
+describe('office', function () {
+
+    describe('formatOffice', function () {
+        it('should format office for display', function () {
+            const OFFICE = {
+                id: 1423,
+                name: "Bordeaux",
+                address: {
+                    street: "39 Rue du Château d'Eau",
+                    city: "Bordeaux", country: "France", zip: "33000",
+                },
+                drivers: [{
+                    id: 3, vehicle: 'renault',
+                    first: 'Daniel', last: 'RICCARDO',
+                    seniority: 5, age: 30,
+                }, {
+                    id: 33, vehicle: 'Honda',
+                    first: 'Max', last: 'VERSTAPPEN',
+                    seniority: 3, age: 22,
+                }, {
+                    id: 14, vehicle: 'mercedes',
+                    first: 'Lewis', last: 'HAMILTON',
+                    seniority: 12, age: 34,
+                },
+                ]
+            };
+            const EXPECTED = {
+                name: "Bordeaux",
+                address: "39 Rue du Château d'Eau, Bordeaux, France 33000",
+                drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
+            };
+            expect(formatOffice(OFFICE)).toEqual(EXPECTED);
+        });
+    });
+});

--- a/office/office.test.js
+++ b/office/office.test.js
@@ -29,7 +29,7 @@ describe('office', function () {
             const EXPECTED = {
                 name: "Bordeaux",
                 address: "39 Rue du Château d'Eau, Bordeaux, France 33000",
-                drivers: "Daniel RICCARDO, Max VERSTAPPEN, Lewis HAMILTON"
+                drivers: "Daniel RICCARDO (5), Max VERSTAPPEN (3), Lewis HAMILTON (12)"
             };
             expect(formatOffice(OFFICE)).toEqual(EXPECTED);
         });

--- a/office/office.test.js
+++ b/office/office.test.js
@@ -29,7 +29,7 @@ describe('office', function () {
             const EXPECTED = {
                 name: "Bordeaux",
                 address: "39 Rue du Château d'Eau, Bordeaux, France 33000",
-                drivers: "Daniel RICCARDO (5), Max VERSTAPPEN (3), Lewis HAMILTON (12)"
+                drivers: "Lewis HAMILTON (12), Daniel RICCARDO (5), Max VERSTAPPEN (3)"
             };
             expect(formatOffice(OFFICE)).toEqual(EXPECTED);
         });


### PR DESCRIPTION
## What this changes:

**Before:**
![image](https://user-images.githubusercontent.com/793700/68905212-ae317680-0740-11ea-990a-0a9a907dbd67.png)

**After:**
![image](https://user-images.githubusercontent.com/793700/68929126-f75ae800-078b-11ea-8001-d566e5e7b576.png)

## Context:
PM's request: https://github.com/euzuro/coding-for-code-review/issues/14

## How to reproduce: 
- Open admin page http://bikefood.io/admin
- Click on "offices" tab
- *Observe:* Drivers' seniority is shown and they are ordered